### PR TITLE
Perf/add requests limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^7.4.2",
+        "@nestjs/throttler": "^6.2.1",
         "@stellar/freighter-api": "^3.0.0",
         "@stellar/stellar-sdk": "^12.3.0",
         "dotenv": "^16.4.5",
@@ -1803,6 +1804,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.2.1.tgz",
+      "integrity": "sha512-vdt6VjhKC6vcLBJRUb97IuR6Htykn5kokZzmT8+S5XFOLLjUF7rzRpr+nUOhK9pi1L0hhbzSf2v2FJl4v64EJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^7.4.2",
+    "@nestjs/throttler": "^6.2.1",
     "@stellar/freighter-api": "^3.0.0",
     "@stellar/stellar-sdk": "^12.3.0",
     "dotenv": "^16.4.5",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,24 @@
 import { Module } from "@nestjs/common";
 import { StellarContractModule } from "./stellar-contract/stellar-contract.module";
+import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
+import { APP_GUARD } from "@nestjs/core";
 
 @Module({
-  imports: [StellarContractModule],
+  imports: [
+    StellarContractModule,
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 50,
+      },
+    ]),
+  ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}


### PR DESCRIPTION
### **Pull Request Title:**
feat: Add rate limiting to API using `nestjs/throttler`

---

### **Description:**
This PR introduces a rate limiting mechanism to the API using the `nestjs/throttler` package. The feature ensures that each client has a limit on the number of API requests they can make within a specific time frame, improving security and preventing abuse.

---

### **Changes:**
- **chore:** Installed `@nestjs/throttler` package.
- **feat:** Implemented rate limiting for API calls per client.

---

### **Summary of Changes:**
- Added rate limiting logic in the API.
- Configured `nestjs/throttler` to limit the number of requests per client.
- Modified `app.module.ts` to include the throttler module.
- Adjusted configuration to set a limit of X requests per Y seconds (adjust as necessary).

---

### **Additions:**
- **+30** lines added to implement rate limiting.
- **@nestjs/throttler** installed as a new dependency.

### **Deletions:**
- **-2** lines removed as part of the module integration.

---

### **Testing:**
- Rate limiting tested by making multiple API requests from a single client.
- Verified that the rate limit is enforced as expected and proper error handling is in place when the limit is exceeded.

---

### **Additional Notes:**
- Ensure that the rate limits set in the configuration align with the API's expected usage and scale.
- Documentation updated (if necessary) to reflect the new rate limit rules.

---

### **Related Issue:**
N/A (Add a link to any issue if applicable)
